### PR TITLE
Several fixes

### DIFF
--- a/fireworks_poe_bot/__main__.py
+++ b/fireworks_poe_bot/__main__.py
@@ -87,12 +87,12 @@ def main(args=None):
         model = text_model_spec.model
         api_key = text_model_spec.API_KEY
         if (
-            text_model_spec.account_override is not None
-            or text_model_spec.model_override is not None
+            text_model_spec.endpoint_account_override is not None
+            or text_model_spec.endpoint_model_override is not None
         ):
             _, account, _, model = model.split("/")
-            account = text_model_spec.account_override or account
-            model = text_model_spec.model_override or model
+            account = text_model_spec.endpoint_account_override or account
+            model = text_model_spec.endpoint_model_override or model
             model_fqn = f"accounts/{account}/models/{model}"
         else:
             model_fqn = model
@@ -110,12 +110,12 @@ def main(args=None):
         model = image_model_spec.model
         api_key = image_model_spec.API_KEY
         if (
-            image_model_spec.account_override is not None
-            or image_model_spec.model_override is not None
+            image_model_spec.endpoint_account_override is not None
+            or image_model_spec.endpoint_model_override is not None
         ):
             _, account, _, model = model.split("/")
-            account = image_model_spec.account_override or account
-            model = image_model_spec.model_override or model
+            account = image_model_spec.endpoint_account_override or account
+            model = image_model_spec.endpoint_model_override or model
             model_fqn = f"accounts/{account}/models/{model}"
         else:
             model_fqn = model
@@ -132,12 +132,12 @@ def main(args=None):
         model = qr_model_spec.model
         api_key = qr_model_spec.API_KEY
         if (
-            qr_model_spec.account_override is not None
-            or qr_model_spec.model_override is not None
+            qr_model_spec.endpoint_account_override is not None
+            or qr_model_spec.endpoint_model_override is not None
         ):
             _, account, _, model = model.split("/")
-            account = qr_model_spec.account_override or account
-            model = qr_model_spec.model_override or model
+            account = qr_model_spec.endpoint_account_override or account
+            model = qr_model_spec.endpoint_model_override or model
             model_fqn = f"accounts/{account}/models/{model}"
         else:
             model_fqn = model

--- a/fireworks_poe_bot/config.py
+++ b/fireworks_poe_bot/config.py
@@ -8,8 +8,8 @@ class ModelConfig(BaseModel):
     model: str
     API_KEY: str
 
-    account_override: Optional[str] = None
-    model_override: Optional[str] = None
+    endpoint_account_override: Optional[str] = None
+    endpoint_model_override: Optional[str] = None
 
 class TextModelConfig(ModelConfig):
     allow_attachments: Optional[bool] = False

--- a/fireworks_poe_bot/fw_poe_image_bot.py
+++ b/fireworks_poe_bot/fw_poe_image_bot.py
@@ -218,7 +218,7 @@ class FireworksPoeImageBot(PoeBot):
             public_image_url = self._upload_image_to_gcs(
                 answer.image, self.gcs_bucket_name
             )
-            yield PartialResponse(text=f"![image]({public_image_url})")
+            response_text = f"![image]({public_image_url})"
 
             end_t = time.time()
             elapsed_sec = end_t - start_t
@@ -227,11 +227,13 @@ class FireworksPoeImageBot(PoeBot):
                     "severity": "INFO",
                     "msg": "Request completed",
                     **query.dict(),
+                    "response": response_text,
                     "elapsed_sec": elapsed_sec,
                     "elapsed_sec_inference": end_t_inference - start_t,
                     "elapsed_sec_upload": end_t - start_t_encode,
                 }
             )
+            yield PartialResponse(text=response_text)
             yield ServerSentEvent(event="done")
             return
         except InvalidRequestError as e:

--- a/fireworks_poe_bot/fw_poe_qr_bot.py
+++ b/fireworks_poe_bot/fw_poe_qr_bot.py
@@ -226,7 +226,7 @@ class FireworksPoeQRBot(PoeBot):
             public_image_url = self._upload_image_to_gcs(
                 answer.image, self.gcs_bucket_name
             )
-            yield PartialResponse(text=f"![image]({public_image_url})")
+            response_text = f"![image]({public_image_url})"
 
             end_t = time.time()
             elapsed_sec = end_t - start_t
@@ -235,11 +235,13 @@ class FireworksPoeQRBot(PoeBot):
                     "severity": "INFO",
                     "msg": "Request completed",
                     **query.dict(),
+                    response: response_text,
                     "elapsed_sec": elapsed_sec,
                     "elapsed_sec_inference": end_t_inference - start_t,
                     "elapsed_sec_upload": end_t - start_t_encode,
                 }
             )
+            yield PartialResponse(text=response_text)
             yield ServerSentEvent(event="done")
             return
         except InvalidRequestError as e:


### PR DESCRIPTION
* Properly log responses in QR and image bot
* Rename `model_override` and `account_override` so pydantic quits yelling at startup