### PR TITLE
Add new flags to QR bot and tweak defaults

### DIFF
--- a/fireworks_poe_bot/fastapi_poe/base.py
+++ b/fireworks_poe_bot/fastapi_poe/base.py
@@ -275,6 +275,11 @@ def make_app(
             raise HTTPException(status_code=404, detail=f"Bot {bot_fqn} not found")
         return bots[bot_fqn]
 
+    @app.get("/")
+    async def index() -> Response:
+        # Default endpoint for health checks
+        return HTMLResponse("It works!")
+
     @app.get("/accounts/{account}/models/{model}")
     async def index(account: str, model: str) -> Response:
         bot = find_bot(account, model)

--- a/fireworks_poe_bot/fw_poe_qr_bot.py
+++ b/fireworks_poe_bot/fw_poe_qr_bot.py
@@ -48,11 +48,11 @@ def parse_input(input_string, default_qr_strength, default_prompt_strength):
             next_flag_idx = len(input_string)
 
         # Parse the flag and its arguments
-        if input_string.startswith('--qr'):
-            qr_prompt = input_string[len("--qr"):next_flag_idx].strip()
-            input_string = input_string[next_flag_idx:].strip()
-        elif input_string.startswith('--qr-strength'):
+        if input_string.startswith('--qr-strength'):
             qr_strength = float(input_string[len("--qr-strength"):next_flag_idx].strip())
+            input_string = input_string[next_flag_idx:].strip()
+        elif input_string.startswith('--qr'):
+            qr_prompt = input_string[len("--qr"):next_flag_idx].strip()
             input_string = input_string[next_flag_idx:].strip()
         elif input_string.startswith('--prompt-strength'):
             prompt_strength = int(input_string[len("--prompt-strength"):next_flag_idx].strip())
@@ -278,7 +278,8 @@ class FireworksPoeQRBot(PoeBot):
             public_image_url = self._upload_image_to_gcs(
                 answer.image, self.gcs_bucket_name
             )
-            response_text = f"![image]({public_image_url})"
+
+            response_text = f"![{prompt}]({public_image_url})"
 
             end_t = time.time()
             elapsed_sec = end_t - start_t


### PR DESCRIPTION
Now the user can control the QR strength, prompt strength, and model to use in the QR bot. Also tweaked defaults. Results are looking better

![Cow_in_a_field](https://github.com/fw-ai/fireworks_poe_bot/assets/4685384/2f71b483-f743-432d-b18b-0b22c29afa1e)
![image (2)](https://github.com/fw-ai/fireworks_poe_bot/assets/4685384/3391b0b0-0f41-4b89-bd6e-70e3a34b7ccf)
![image (3)](https://github.com/fw-ai/fireworks_poe_bot/assets/4685384/52350db1-f5dd-4487-88f6-fd82acdfacfd)
![image (4)](https://github.com/fw-ai/fireworks_poe_bot/assets/4685384/266f6cfc-e38c-4647-bd1b-543d54323473)
