### PR TITLE
Fix system prompt override

### DIFF
--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -236,20 +236,12 @@ class FireworksPoeTextBot(PoeBot):
                     messages.append({"role": role, "content": protocol_message.content})
 
             if self.system_prompt_override is not None:
-                system_prompt_msg = None
-                for msg in messages:
-                    if msg["role"] == "system":
-                        system_prompt_msg = msg
-                        break
-                if system_prompt_msg is None:
+                if len(messages) == 0 or messages[0]["role"] != "system":
                     system_prompt_msg = {
                         "role": "system",
+                        "content": {"type": "text", "text": self.system_prompt_override}
                     }
                     messages.insert(0, system_prompt_msg)
-
-                system_prompt_msg["content"] = [
-                    {"type": "text", "text": self.system_prompt_override},
-                ]
 
             if self.chat_format == "alpaca":
                 # Discard all messages except "system" and the last "user"

--- a/test/test_poebot.py
+++ b/test/test_poebot.py
@@ -74,10 +74,11 @@ class TestFWPoeBot(unittest.IsolatedAsyncioTestCase):
             input_image_size=-1,
             prompt_truncate_len=1024,
             max_tokens=2048,
-            system_prompt_override=None,
+            system_prompt_override="",
             additional_args=None,
             chat_format=None,
             alpaca_instruction_msg=None,
+            meta_response=None,
             completion_async_method=self.completion_async_method,
         )
 
@@ -192,7 +193,6 @@ class TestFWPoeBot(unittest.IsolatedAsyncioTestCase):
                 ProtocolMessage(role="user", content="bar"),
             ]
         )
-        import pdb; pdb.set_trace()
         self.assertEqual(resp, "foo")
 
 


### PR DESCRIPTION
The gating logic was slightly off here and would trigger replacing the system message passed in the query