### PR TITLE
Fix merge messages groups for system prompt

### DIFF
--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -331,6 +331,9 @@ class FireworksPoeTextBot(PoeBot):
                             assert msg[0]["type"] == "text"
                             text.append(msg[0]["text"])
                             images.extend(msg[1:])
+                        elif isinstance(msg, dict):
+                            assert msg["type"] == "text"
+                            text.append(msg["text"])
                     if images:
                         return [{"type": "text", "text": " ".join(text)}, *images]
                     return " ".join(text)


### PR DESCRIPTION
ATT

Sometimes this msg coming in looks like

{'type': 'text', 'text': 'I AM SYSTEM PROMPT'}, and we zero it out