### PR TITLE
Improve ErrorResponse User Messages

### DIFF
--- a/fireworks_poe_bot/fw_poe_image_bot.py
+++ b/fireworks_poe_bot/fw_poe_image_bot.py
@@ -288,9 +288,20 @@ class FireworksPoeImageBot(PoeBot):
             )
             if "prompt is too long" in str(e):
                 error_type = "user_message_too_long"
+                yield ErrorResponse(
+                    allow_retry=False,
+                    error_type=error_type,
+                    raw_response=e,
+                    text="The user message is too long. Please try again with a shorter message."
+                )
             else:
                 error_type = None
-            yield ErrorResponse(allow_retry=False, error_type=error_type, text=str(e))
+                yield ErrorResponse(
+                    allow_retry=False,
+                    error_type=error_type,
+                    raw_response=e,
+                    text="The bot encountered an unexpected error."
+                )
             return
         finally:
             fireworks.client.api_key = orig_api_key

--- a/fireworks_poe_bot/fw_poe_qr_bot.py
+++ b/fireworks_poe_bot/fw_poe_qr_bot.py
@@ -341,9 +341,20 @@ class FireworksPoeQRBot(PoeBot):
             )
             if "prompt is too long" in str(e):
                 error_type = "user_message_too_long"
+                yield ErrorResponse(
+                    allow_retry=False,
+                    error_type=error_type,
+                    raw_response=e,
+                    text="The user message is too long. Please try again with a shorter message."
+                )
             else:
                 error_type = None
-            yield ErrorResponse(allow_retry=False, error_type=error_type, text=str(e))
+                yield ErrorResponse(
+                    allow_retry=False,
+                    error_type=error_type,
+                    raw_response=e,
+                    text="The bot encountered an unexpected error."
+                )
             return
         finally:
             fireworks.client.api_key = orig_api_key

--- a/fireworks_poe_bot/fw_poe_stability_image_bot.py
+++ b/fireworks_poe_bot/fw_poe_stability_image_bot.py
@@ -287,9 +287,20 @@ class FireworksPoeStabilityImageBot(PoeBot):
             )
             if "prompt is too long" in str(e):
                 error_type = "user_message_too_long"
+                yield ErrorResponse(
+                    allow_retry=False,
+                    error_type=error_type,
+                    raw_response=e,
+                    text="The user message is too long. Please try again with a shorter message."
+                )
             else:
                 error_type = None
-            yield ErrorResponse(allow_retry=False, error_type=error_type, text=str(e))
+                yield ErrorResponse(
+                    allow_retry=False,
+                    error_type=error_type,
+                    raw_response=e,
+                    text="The bot encountered an unexpected error."
+                )
             return
 
     # Function to upload a PIL Image to an S3 bucket with a presigned URL

--- a/fireworks_poe_bot/fw_poe_video_bot.py
+++ b/fireworks_poe_bot/fw_poe_video_bot.py
@@ -214,7 +214,11 @@ class FireworksPoeVideoBot(PoeBot):
                         protocol_message.attachments[0].url
                     )
                 except Exception as e:
-                    yield ErrorResponse(allow_retry=False, text=str(e))
+                    yield ErrorResponse(
+                        allow_retry=False,
+                        raw_response=e,
+                        text="The bot encountered an error while processing an attached image."
+                    )
                     raise RuntimeError(str(e))
             else:
                 yield self.replace_response_event(
@@ -311,9 +315,20 @@ class FireworksPoeVideoBot(PoeBot):
             )
             if "prompt is too long" in str(e):
                 error_type = "user_message_too_long"
+                yield ErrorResponse(
+                    allow_retry=False,
+                    error_type=error_type,
+                    raw_response=e,
+                    text="The user message is too long. Please try again with a shorter message."
+                )
             else:
                 error_type = None
-            yield ErrorResponse(allow_retry=False, error_type=error_type, text=str(e))
+                yield ErrorResponse(
+                    allow_retry=False,
+                    error_type=error_type,
+                    raw_response=e,
+                    text="The bot encountered an unexpected error."
+                )
             return
         finally:
             fireworks.client.api_key = orig_api_key


### PR DESCRIPTION
We recently [changed the ErrorResponse](https://creator.poe.com/changelog) behavior to show the `text` field as the user-facing error message. This allows for custom error messages.

- Remove raw error messages from `text` field of `ErrorResponse`, and put them in `raw_response` field instead.