### PR TITLE
[ez] Rename to be inclusive to agent

### DIFF
--- a/fireworks_poe_bot/__main__.py
+++ b/fireworks_poe_bot/__main__.py
@@ -125,9 +125,9 @@ def main(args=None):
             super().__init__()
             self.bots = bots
 
-        def find_bot(self, account: str, model: str) -> fastapi_poe.PoeBot:
-            model_fqn = f"accounts/{account}/models/{model}"
-            agent_fqn = f"accounts/{account}/agents/{model}"
+        def find_bot(self, account: str, model_or_agent: str) -> fastapi_poe.PoeBot:
+            model_fqn = f"accounts/{account}/models/{model_or_agent}"
+            agent_fqn = f"accounts/{account}/agents/{model_or_agent}"
             bot = self.bots.get(model_fqn) or self.bots.get(agent_fqn)
             if bot is None:
                 raise HTTPException(status_code=404, detail=f"Model {model_fqn} or agent {agent_fqn} not found")
@@ -136,9 +136,10 @@ def main(args=None):
         def find_bot_from_query_params(self, params) -> fastapi_poe.PoeBot:
             if "account" not in params:
                 raise HTTPException(status_code=400, detail=f"Missing account query parameter")
-            if "model" not in params:
-                raise HTTPException(status_code=400, detail=f"Missing model query parameter")
-            return self.find_bot(params["account"], params["model"])
+            model_or_agent = params.get("model") or params.get("agent")
+            if model_or_agent is None:
+                raise HTTPException(status_code=400, detail=f"Missing model or agent query parameter")
+            return self.find_bot(params["account"], model_or_agent)
 
         async def get_response_with_context(
             self, request: fastapi_poe.QueryRequest, context: fastapi_poe.RequestContext

--- a/fireworks_poe_bot/__main__.py
+++ b/fireworks_poe_bot/__main__.py
@@ -126,10 +126,12 @@ def main(args=None):
             self.bots = bots
 
         def find_bot(self, account: str, model: str) -> fastapi_poe.PoeBot:
-            bot_fqn = f"accounts/{account}/models/{model}"
-            if bot_fqn not in self.bots:
-                raise HTTPException(status_code=404, detail=f"Bot {bot_fqn} not found")
-            return bots[bot_fqn]
+            model_fqn = f"accounts/{account}/models/{model}"
+            agent_fqn = f"accounts/{account}/agents/{model}"
+            bot = self.bots.get(model_fqn) or self.bots.get(agent_fqn)
+            if bot is None:
+                raise HTTPException(status_code=404, detail=f"Model {model_fqn} or agent {agent_fqn} not found")
+            return bot
 
         def find_bot_from_query_params(self, params) -> fastapi_poe.PoeBot:
             if "account" not in params:


### PR DESCRIPTION
## Summary
This change makes sure that when poe bot connects to this server, we are able to route to the right backend model.

## Tests
Verified through locally running the fw_poe_bot 
```
FIREWORKS_API_KEY=$FW_DEV_API_KEY python -m fireworks_poe_bot
```
And connected to poe simulator
```
BOT_SERVER=localhost:80 python -m simulator_poe
```
they worked.
```
Poe server > ok tell me a one liner joke

Bot server > Here is
 a one-liner
 joke for you
:

"I told my
 wife she was drawing
 her eyebrows too high
, she looked surprised
."
```