### PR TITLE
remove merging logic for image bots

### DIFF
--- a/fireworks_poe_bot/fw_poe_flux_image_bot.py
+++ b/fireworks_poe_bot/fw_poe_flux_image_bot.py
@@ -210,20 +210,15 @@ class FireworksPoeFluxImageBot(PoeBot):
             return
 
     def _normalize_messages(self, messages: List[Dict[str, str]]) -> List[Dict[str, str]]:
-        # Ensure assistant messages are preceded by user messages and merge adjacent messages
+        # Ensure assistant messages are preceded by user messages
         for i in range(len(messages) - 1, -1, -1):
             if messages[i]["role"] == "assistant" and (i == 0 or messages[i - 1]["role"] != "user"):
                 messages.insert(i, {"role": "user", "content": ""})
 
-        merged_messages = []
-        for role, group in groupby(messages, key=lambda x: x["role"]):
-            content = " ".join(message["content"] for message in group)
-            merged_messages.append({"role": role, "content": content})
+        if messages[-1]["role"] != "user":
+            messages.append({"role": "user", "content": ""})
 
-        if merged_messages[-1]["role"] != "user":
-            merged_messages.append({"role": "user", "content": ""})
-
-        return merged_messages
+        return messages
 
     async def _generate_image_async(self, prompt: str, aspect_ratio: Optional[str]) -> Optional[Image.Image]:
         async with httpx.AsyncClient(timeout=None) as client:  # Set timeout to None

--- a/fireworks_poe_bot/fw_poe_image_bot.py
+++ b/fireworks_poe_bot/fw_poe_image_bot.py
@@ -176,15 +176,6 @@ class FireworksPoeImageBot(PoeBot):
                     )
                     messages.insert(i, {"role": "user", "content": ""})
 
-            # Merge adjacent messages from the same role
-            merged_messages = []
-
-            for role, group in groupby(messages, key=lambda x: x["role"]):
-                content = " ".join(message["content"] for message in group)
-                merged_messages.append({"role": role, "content": content})
-
-            messages = merged_messages
-
             # Ensure last message is a user message
             if messages[-1]["role"] != "user":
                 self._log_warn({"msg": f"Last message {messages[-1]} not a user message"})

--- a/fireworks_poe_bot/fw_poe_stability_image_bot.py
+++ b/fireworks_poe_bot/fw_poe_stability_image_bot.py
@@ -169,15 +169,6 @@ class FireworksPoeStabilityImageBot(PoeBot):
                     )
                     messages.insert(i, {"role": "user", "content": ""})
 
-            # Merge adjacent messages from the same role
-            merged_messages = []
-
-            for role, group in groupby(messages, key=lambda x: x["role"]):
-                content = " ".join(message["content"] for message in group)
-                merged_messages.append({"role": role, "content": content})
-
-            messages = merged_messages
-
             # Ensure last message is a user message
             if messages[-1]["role"] != "user":
                 self._log_warn({"msg": f"Last message {messages[-1]} not a user message"})


### PR DESCRIPTION
According to poe side, merging content for image bots is no long needed. Removing the logic for all image bots.