### PR TITLE
Fix/audio video error handling

### DIFF
--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -316,7 +316,7 @@ class FireworksPoeTextBot(PoeBot):
                             "request_id": request_id,
                             "content_type": attachment.content_type,
                             "input_image_size": self.input_image_size,
-                            "input_image_size_type": type(self.input_image_size),
+                            "input_image_size_type": str(type(self.input_image_size)),  # <-- Convert to string
                             "supported_check": attachment.content_type in ["image/png", "image/jpeg"],
                             "full_condition": (self.input_image_size is not None and attachment.content_type in ["image/png", "image/jpeg"])
                         })

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -247,6 +247,15 @@ class FireworksPoeTextBot(PoeBot):
                     role = "assistant"
                 else:
                     role = protocol_message.role
+                    # DEBUG: Log all message info
+                    self._log_info({
+                        "msg": "DEBUG: Processing message", 
+                        "request_id": request_id,
+                        "role": role,
+                        "has_attachments": bool(protocol_message.attachments),
+                        "attachment_count": len(protocol_message.attachments) if protocol_message.attachments else 0,
+                        "attachment_types": [att.content_type for att in protocol_message.attachments] if protocol_message.attachments else []
+                    })
                     # NB: using `input_image_size` as a flag to determine whether the
                     # model supports image understanding natively
                     if protocol_message.attachments and len(protocol_message.attachments) > 0:

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -366,7 +366,9 @@ class FireworksPoeTextBot(PoeBot):
                                 "content_type": attachment.content_type,
                                 "attachment_name": getattr(attachment, 'name', 'unknown'),
                                 "input_image_size": self.input_image_size,
-                                "condition_that_triggered_this": "ADD_THE_ACTUAL_CONDITION_HERE"  # Replace with the actual if condition
+                                "condition_that_triggered_this": f"else clause - parsed_content is None: {attachment.parsed_content is None}",
+                                "parsed_content_exists": attachment.parsed_content is not None,
+                                "parsed_content_preview": str(attachment.parsed_content)[:200] if attachment.parsed_content else None
                             })
                             error_msg = f"Unsupported file type: {attachment.content_type}. This model only supports text input and images (PNG, JPEG)."
                             self._log_warn({

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -359,6 +359,15 @@ class FireworksPoeTextBot(PoeBot):
                         
                         # Handle any other unsupported file types
                         else:
+                            # DEBUG
+                            self._log_info({
+                                "msg": "DEBUG: About to trigger unsupported file type error",
+                                "request_id": request_id,
+                                "content_type": attachment.content_type,
+                                "attachment_name": getattr(attachment, 'name', 'unknown'),
+                                "input_image_size": self.input_image_size,
+                                "condition_that_triggered_this": "ADD_THE_ACTUAL_CONDITION_HERE"  # Replace with the actual if condition
+                            })
                             error_msg = f"Unsupported file type: {attachment.content_type}. This model only supports text input and images (PNG, JPEG)."
                             self._log_warn({
                                 "msg": "Unsupported file type",

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -297,29 +297,11 @@ class FireworksPoeTextBot(PoeBot):
                     role = "assistant"
                 else:
                     role = protocol_message.role
-                    # DEBUG: Log all message info
-                    self._log_info({
-                        "msg": "DEBUG: Processing message", 
-                        "request_id": request_id,
-                        "role": role,
-                        "has_attachments": bool(protocol_message.attachments),
-                        "attachment_count": len(protocol_message.attachments) if protocol_message.attachments else 0,
-                        "attachment_types": [att.content_type for att in protocol_message.attachments] if protocol_message.attachments else []
-                    })
                     # NB: using `input_image_size` as a flag to determine whether the
                     # model supports image understanding natively
                     if protocol_message.attachments and len(protocol_message.attachments) > 0:
                         attachment = protocol_message.attachments[0]
-                        # DEBUG: Log attachment analysis details
-                        self._log_info({
-                            "msg": "DEBUG: Attachment analysis",
-                            "request_id": request_id,
-                            "content_type": attachment.content_type,
-                            "input_image_size": self.input_image_size,
-                            "input_image_size_type": str(type(self.input_image_size)),  # <-- Convert to string
-                            "supported_check": attachment.content_type in ["image/png", "image/jpeg"],
-                            "full_condition": (self.input_image_size is not None and attachment.content_type in ["image/png", "image/jpeg"])
-                        })
+                        
                         # Check for unsupported audio files
                         if attachment.content_type in self.UNSUPPORTED_AUDIO_TYPES:
                             error_msg = f"Audio files are not supported. The model cannot process {attachment.content_type} files. Please use text input instead."

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -52,6 +52,15 @@ class TextModelConfig(ModelConfig):
 
 @register_bot_plugin("text_models", TextModelConfig)
 class FireworksPoeTextBot(PoeBot):
+    UNSUPPORTED_AUDIO_TYPES = [
+        "audio/mpeg", "audio/mp3", "audio/wav", "audio/ogg", 
+        "audio/m4a", "audio/aac", "audio/flac", "audio/webm"
+    ]
+
+    UNSUPPORTED_VIDEO_TYPES = [
+        "video/mp4", "video/avi", "video/mov", "video/wmv", 
+        "video/flv", "video/webm", "video/mkv", "video/m4v"
+    ]
     def __init__(
         self,
         model: str,
@@ -240,22 +249,57 @@ class FireworksPoeTextBot(PoeBot):
                     role = protocol_message.role
                     # NB: using `input_image_size` as a flag to determine whether the
                     # model supports image understanding natively
-                    if self.input_image_size is not None and protocol_message.attachments and len(protocol_message.attachments) > 0 and protocol_message.attachments[
-                        0
-                    ].content_type in ["image/png", "image/jpeg"]:
-                        try:
-                            img_buffer = (
-                                await self.download_image_and_save_to_bytes(
-                                    protocol_message.attachments[0].url
-                                )
-                            )
-                        except Exception as e:
-                            yield ErrorResponse(allow_retry=False, text=str(e))
-                            raise RuntimeError(str(e))
-                    elif protocol_message.attachments and len(protocol_message.attachments) > 0 and protocol_message.attachments[0].parsed_content is not None:
-                        attachment_parsed_content = protocol_message.attachments[
-                            0
-                        ].parsed_content
+                    if protocol_message.attachments and len(protocol_message.attachments) > 0:
+                        attachment = protocol_message.attachments[0]
+                        
+                        # Check for unsupported audio files
+                        if attachment.content_type in self.UNSUPPORTED_AUDIO_TYPES:
+                            error_msg = f"Audio files are not supported. The model cannot process {attachment.content_type} files. Please use text input instead."
+                            self._log_warn({
+                                "msg": "Unsupported audio file type",
+                                "request_id": request_id,
+                                "content_type": attachment.content_type,
+                                "attachment_name": getattr(attachment, 'name', 'unknown')
+                            })
+                            yield ErrorResponse(allow_retry=False, text=error_msg)
+                            return
+                        
+                        # Check for unsupported video files
+                        elif attachment.content_type in self.UNSUPPORTED_VIDEO_TYPES:
+                            error_msg = f"Video files are not supported. The model cannot process {attachment.content_type} files. Please use text input or supported image formats (PNG, JPEG) instead."
+                            self._log_warn({
+                                "msg": "Unsupported video file type", 
+                                "request_id": request_id,
+                                "content_type": attachment.content_type,
+                                "attachment_name": getattr(attachment, 'name', 'unknown')
+                            })
+                            yield ErrorResponse(allow_retry=False, text=error_msg)
+                            return
+                        
+                        # Handle supported image files (existing logic)
+                        elif (self.input_image_size is not None and 
+                            attachment.content_type in ["image/png", "image/jpeg"]):
+                            try:
+                                img_buffer = await self.download_image_and_save_to_bytes(attachment.url)
+                            except Exception as e:
+                                yield ErrorResponse(allow_retry=False, text=str(e))
+                                raise RuntimeError(str(e))
+                        
+                        # Handle files with parsed content (existing logic)
+                        elif attachment.parsed_content is not None:
+                            attachment_parsed_content = attachment.parsed_content
+                        
+                        # Handle any other unsupported file types
+                        else:
+                            error_msg = f"Unsupported file type: {attachment.content_type}. This model only supports text input and images (PNG, JPEG)."
+                            self._log_warn({
+                                "msg": "Unsupported file type",
+                                "request_id": request_id, 
+                                "content_type": attachment.content_type,
+                                "attachment_name": getattr(attachment, 'name', 'unknown')
+                            })
+                            yield ErrorResponse(allow_retry=False, text=error_msg)
+                            return
                 content = []
                 self._log_info(
                     {

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -59,7 +59,7 @@ class FireworksPoeTextBot(PoeBot):
 
     UNSUPPORTED_VIDEO_TYPES = [
         "video/mp4", "video/avi", "video/mov", "video/wmv", 
-        "video/flv", "video/webm", "video/mkv", "video/m4v"
+        "video/flv", "video/webm", "video/mkv", "video/m4v", "video/quicktime"
     ]
     def __init__(
         self,

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -310,7 +310,16 @@ class FireworksPoeTextBot(PoeBot):
                     # model supports image understanding natively
                     if protocol_message.attachments and len(protocol_message.attachments) > 0:
                         attachment = protocol_message.attachments[0]
-                        
+                        # DEBUG: Log attachment analysis details
+                        self._log_info({
+                            "msg": "DEBUG: Attachment analysis",
+                            "request_id": request_id,
+                            "content_type": attachment.content_type,
+                            "input_image_size": self.input_image_size,
+                            "input_image_size_type": type(self.input_image_size),
+                            "supported_check": attachment.content_type in ["image/png", "image/jpeg"],
+                            "full_condition": (self.input_image_size is not None and attachment.content_type in ["image/png", "image/jpeg"])
+                        })
                         # Check for unsupported audio files
                         if attachment.content_type in self.UNSUPPORTED_AUDIO_TYPES:
                             error_msg = f"Audio files are not supported. The model cannot process {attachment.content_type} files. Please use text input instead."

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -53,13 +53,63 @@ class TextModelConfig(ModelConfig):
 @register_bot_plugin("text_models", TextModelConfig)
 class FireworksPoeTextBot(PoeBot):
     UNSUPPORTED_AUDIO_TYPES = [
-        "audio/mpeg", "audio/mp3", "audio/wav", "audio/ogg", 
-        "audio/m4a", "audio/aac", "audio/flac", "audio/webm"
+        # Standard audio MIME types
+        "audio/mpeg", "audio/mp3", "audio/wav", "audio/wave", "audio/ogg", 
+        "audio/m4a", "audio/aac", "audio/flac", "audio/webm", "audio/opus",
+        "audio/vorbis", "audio/3gpp", "audio/3gpp2", "audio/amr", 
+        "audio/basic", "audio/midi", "audio/x-midi", "audio/mp4",
+        
+        # Extended and legacy audio types
+        "audio/x-mp3", "audio/x-mpeg", "audio/mpeg3", "audio/x-wav", 
+        "audio/x-wave", "audio/vnd.wav", "audio/x-pn-wav", "audio/x-flac",
+        "audio/x-m4a", "audio/x-aac", "audio/x-aiff", "audio/aiff",
+        "audio/x-ms-wma", "audio/x-ms-wmv", "audio/wma", "audio/ac3",
+        "audio/eac3", "audio/x-ac3", "audio/vnd.dolby.heaac.1",
+        "audio/vnd.dolby.heaac.2", "audio/x-caf", "audio/x-gsm",
+        
+        # Application types sometimes used for audio
+        "application/ogg", "application/x-ogg", "application/vnd.ms-asf",
+        "application/x-ms-wmz", "application/x-ms-wmd",
+        
+        # Other variations
+        "audio/x-realaudio", "audio/vnd.rn-realaudio", "audio/x-pn-realaudio",
+        "audio/vnd.wave", "audio/L24", "audio/speex", "audio/x-speex",
+        "audio/silk", "audio/vnd.dece.audio", "audio/vnd.digital-winds",
+        "audio/x-matroska"
     ]
 
     UNSUPPORTED_VIDEO_TYPES = [
-        "video/mp4", "video/avi", "video/mov", "video/wmv", 
-        "video/flv", "video/webm", "video/mkv", "video/m4v", "video/quicktime", "video/x-ms-wmv"
+        # Standard video MIME types
+        "video/mp4", "video/mpeg", "video/avi", "video/mov", "video/wmv",
+        "video/flv", "video/webm", "video/mkv", "video/m4v", "video/quicktime",
+        "video/x-ms-wmv", "video/x-ms-asf", "video/x-msvideo", "video/3gpp",
+        "video/3gpp2", "video/x-flv", "video/x-f4v", "video/mp2t",
+        
+        # Extended video types
+        "video/x-mpeg", "video/x-mpeg2", "video/mpeg2", "video/x-dv",
+        "video/dv", "video/x-matroska", "video/x-ms-wm", "video/x-ms-wmx",
+        "video/x-ms-wvx", "video/vnd.ms-asf", "video/x-la-asf",
+        "video/x-ivf", "video/divx", "video/xvid", "video/x-xvid",
+        
+        # Legacy and proprietary formats
+        "video/vnd.rn-realvideo", "video/x-pn-realvideo", "video/realvideo",
+        "video/x-sgi-movie", "video/x-motion-jpeg", "video/x-mjpeg",
+        "video/mjpeg", "video/x-ms-wmp", "video/x-ogm", "video/ogg",
+        "video/theora", "video/x-theora", "video/vp8", "video/vp9",
+        "video/av1", "video/h264", "video/h265", "video/hevc",
+        
+        # Application types sometimes used for video
+        "application/x-troff-msvideo", "application/x-mplayer2",
+        "application/vnd.ms-asf", "application/x-ms-wmz",
+        "application/x-ms-wmd", "application/x-shockwave-flash",
+        "application/x-director", "application/vnd.rn-realmedia",
+        "application/vnd.rn-realmedia-vbr",
+        
+        # Container and mobile formats
+        "video/3gp", "video/3g2", "video/x-3gp", "video/x-3g2",
+        "video/vnd.mpegurl", "video/x-mpegurl", "video/x-matroska-3d",
+        "video/vnd.sealed.mpeg1", "video/vnd.sealed.mpeg4",
+        "video/x-rad-screenplay", "video/x-smv", "video/x-ms-vob"
     ]
     def __init__(
         self,

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -59,7 +59,7 @@ class FireworksPoeTextBot(PoeBot):
 
     UNSUPPORTED_VIDEO_TYPES = [
         "video/mp4", "video/avi", "video/mov", "video/wmv", 
-        "video/flv", "video/webm", "video/mkv", "video/m4v", "video/quicktime"
+        "video/flv", "video/webm", "video/mkv", "video/m4v", "video/quicktime", "video/x-ms-wmv"
     ]
     def __init__(
         self,

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -357,28 +357,6 @@ class FireworksPoeTextBot(PoeBot):
                         elif attachment.parsed_content is not None:
                             attachment_parsed_content = attachment.parsed_content
                         
-                        # Handle any other unsupported file types
-                        else:
-                            # DEBUG
-                            self._log_info({
-                                "msg": "DEBUG: About to trigger unsupported file type error",
-                                "request_id": request_id,
-                                "content_type": attachment.content_type,
-                                "attachment_name": getattr(attachment, 'name', 'unknown'),
-                                "input_image_size": self.input_image_size,
-                                "condition_that_triggered_this": f"else clause - parsed_content is None: {attachment.parsed_content is None}",
-                                "parsed_content_exists": attachment.parsed_content is not None,
-                                "parsed_content_preview": str(attachment.parsed_content)[:200] if attachment.parsed_content else None
-                            })
-                            error_msg = f"Unsupported file type: {attachment.content_type}. This model only supports text input and images (PNG, JPEG)."
-                            self._log_warn({
-                                "msg": "Unsupported file type",
-                                "request_id": request_id, 
-                                "content_type": attachment.content_type,
-                                "attachment_name": getattr(attachment, 'name', 'unknown')
-                            })
-                            yield ErrorResponse(allow_retry=False, text=error_msg)
-                            return
                 content = []
                 self._log_info(
                     {


### PR DESCRIPTION
# Fix audio/video file error handling for all models (although, specifically requested by Quora for Kimi K2)

## Problem
- **Audio files (MP3, WAV)** uploaded to Kimi K2 Poe bot cause silent failures with no response to users
- **Video files (MP4, AVI)** are accepted but cause the model to hallucinate responses instead of proper error handling
- Users get confusing experience with no clear feedback about unsupported file types

## Solution
- Added comprehensive MIME type detection for audio and video files
- Return clear, user-friendly error messages for unsupported file types
- Added proper logging for monitoring unsupported file upload attempts
- Prevents model from attempting to process unsupported media files

## Changes Made
- **Added constants** for comprehensive audio/video MIME type lists
- **Enhanced attachment handling logic** in `fw_poe_text_bot.py` with early error detection
- **Improved error messages** that guide users to supported alternatives
- **Added warning logs** for operational monitoring

## Error Messages
- **Audio files**: "Audio files are not supported. The model cannot process {type} files. Please use text input instead."
- **Video files**: "Video files are not supported. The model cannot process {type} files. Please use text input or supported image formats (PNG, JPEG) instead."
- **Other unsupported**: "Unsupported file type: {type}. This model only supports text input and images (PNG, JPEG)."

## Testing
- ✅ **Dev environment testing**: Deployed and verified with multiple file types (MP4, MOV, FLV)
- ✅ **Logging**: Warning logs generated for monitoring

## Edge Cases Handled
- Files with unexpected MIME types (e.g., MOV detected as `video/quicktime`)

## Backward Compatibility
- ✅ **No breaking changes** to existing supported functionality
- ✅ **Existing image processing** works identically
- ✅ **Text conversations** work identically
- ✅ **PDF and document processing** works identically