### PR TITLE
feat: implement reasoning_content support for GLM/OAI GPT OSS models

### DIFF
--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -623,25 +623,19 @@ class FireworksPoeTextBot(PoeBot):
                             if not reasoning_content_started:
                                 reasoning_content_started = True
                                 yield PartialResponse(
-                                    text="Thinking...\n",
+                                    text="Thinking...\n> ",
                                     raw_response=response,
                                     request_id=response.id,
                                 )
                             
-                            # Format reasoning delta with > prefix
-                            formatted_delta = ""
-                            for line in reasoning_delta.split('\n'):
-                                if line.strip():
-                                    formatted_delta += f"> {line}\n"
-                                elif reasoning_delta.endswith('\n'):
-                                    formatted_delta += "\n"
+                            # Stream the raw reasoning content, replacing newlines with "\n> "
+                            formatted_delta = reasoning_delta.replace('\n', '\n> ')
                             
-                            if formatted_delta:
-                                yield PartialResponse(
-                                    text=formatted_delta,
-                                    raw_response=response,
-                                    request_id=response.id,
-                                )
+                            yield PartialResponse(
+                                text=formatted_delta,
+                                raw_response=response,
+                                request_id=response.id,
+                            )
                             
                             continue
 

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -139,6 +139,25 @@ class FireworksPoeTextBot(PoeBot):
         )
         log_error(payload)
 
+    def _format_reasoning_content(self, reasoning_content: str) -> str:
+        """Format reasoning content in the same style as the old <think> tags"""
+        if not reasoning_content:
+            return ""
+        
+        # Format like the old thinking display
+        formatted_lines = []
+        formatted_lines.append("Thinking...\n")
+        
+        # Add indentation to each line of reasoning content
+        for line in reasoning_content.split('\n'):
+            if line.strip():  # Don't indent empty lines
+                formatted_lines.append(f"> {line}\n")
+            else:
+                formatted_lines.append("\n")
+        
+        formatted_lines.append("\n")  # Add spacing after thinking content
+        return "".join(formatted_lines)
+
     async def _image_has_nsfw_content(self, image_binary: bytes) -> bool:
         files = {
             "image": image_binary,
@@ -564,6 +583,46 @@ class FireworksPoeTextBot(PoeBot):
                     
                     for choice in response.choices:
                         assert isinstance(choice, ChatCompletionResponseStreamChoice)
+
+                        if (self.show_reasoning_content and 
+                            hasattr(choice, 'message') and 
+                            hasattr(choice.message, 'reasoning_content') and 
+                            choice.message.reasoning_content):
+                            reasoning_content = choice.message.reasoning_content
+                            formatted_reasoning = self._format_reasoning_content(reasoning_content)
+                            
+                            if formatted_reasoning:
+                                self._log_info({
+                                    "msg": "Reasoning content found",
+                                    "request_id": request_id,
+                                    "model": self.model,
+                                    "reasoning_length": len(reasoning_content),
+                                })
+                                
+                                yield PartialResponse(
+                                    text=formatted_reasoning,
+                                    raw_response=response,
+                                    request_id=response.id,
+                                )
+                        
+                        # Handle reasoning content in delta for streaming responses
+                        if (self.show_reasoning_content and 
+                            hasattr(choice, 'delta') and 
+                            hasattr(choice.delta, 'reasoning_content') and 
+                            choice.delta.reasoning_content):
+                            reasoning_content = choice.delta.reasoning_content
+                            formatted_reasoning = self._format_reasoning_content(reasoning_content)
+                            
+                            if formatted_reasoning:
+                                yield PartialResponse(
+                                    text=formatted_reasoning,
+                                    raw_response=response,
+                                    request_id=response.id,
+                                )
+                        
+
+
+
                         if choice.delta.content is None:
                             continue
 

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -45,6 +45,7 @@ class TextModelConfig(ModelConfig):
     alpaca_instruction_msg: Optional[str] = None
     vlm_input_image_safety_check: Optional[bool] = False
     replace_think: bool = False
+    show_reasoning_content: bool = False
     model_deployment: Optional[str] = None
 
     meta_response: Optional[MetaResponse] = None
@@ -71,6 +72,7 @@ class FireworksPoeTextBot(PoeBot):
         alpaca_instruction_msg: Optional[str],
         vlm_input_image_safety_check: Optional[bool],
         replace_think: bool,
+        show_reasoning_content: bool,
         model_deployment: Optional[str],
         meta_response: Optional[MetaResponse],
         completion_async_method: Callable = ChatCompletion.acreate,
@@ -92,6 +94,7 @@ class FireworksPoeTextBot(PoeBot):
         self.alpaca_instruction_msg = alpaca_instruction_msg
         self.vlm_input_image_safety_check = vlm_input_image_safety_check
         self.replace_think = replace_think
+        self.show_reasoning_content = show_reasoning_content
         self.model_deployment = model_deployment
         self.system_prompt_override = system_prompt_override
         self.additional_args = additional_args or {}

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -618,6 +618,16 @@ class FireworksPoeTextBot(PoeBot):
                             choice.delta.reasoning_content):
                             
                             reasoning_delta = choice.delta.reasoning_content
+
+                            # DEBUGGING
+                            self._log_info({
+                                "msg": "DEBUG: Reasoning delta details",
+                                "request_id": request_id,
+                                "reasoning_content_started": reasoning_content_started,
+                                "reasoning_delta": reasoning_delta,
+                                "has_regular_content": choice.delta.content is not None,
+                                "regular_content": choice.delta.content,
+                            })
                             
                             # First reasoning chunk - output header once
                             if not reasoning_content_started:
@@ -644,6 +654,14 @@ class FireworksPoeTextBot(PoeBot):
                         # Handle regular content
                         if choice.delta.content is None:
                             continue
+
+                        # DEBUGGING: Log the transition
+                        self._log_info({
+                            "msg": "DEBUG: About to process regular content",
+                            "request_id": request_id,
+                            "reasoning_content_started": reasoning_content_started,
+                            "content": choice.delta.content,
+                        })
 
                         # Transition from reasoning to regular content (only when we have actual content)
                         if reasoning_content_started:

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -557,6 +557,9 @@ class FireworksPoeTextBot(PoeBot):
                     model_with_deployment = f"{self.model}#{self.model_deployment}"
                 else:
                     model_with_deployment = self.model
+
+                accumulated_reasoning_content = ""
+                reasoning_content_started = False
                 
                 async for response in self.completion_async_method(
                     model=model_with_deployment,
@@ -608,23 +611,48 @@ class FireworksPoeTextBot(PoeBot):
                                     request_id=response.id,
                                 )
                         
-                        # Handle reasoning content in delta for streaming responses
+                        # Handle streaming reasoning content
                         if (self.show_reasoning_content and 
                             hasattr(choice, 'delta') and 
                             hasattr(choice.delta, 'reasoning_content') and 
                             choice.delta.reasoning_content):
-                            reasoning_content = choice.delta.reasoning_content
-                            formatted_reasoning = self._format_reasoning_content(reasoning_content)
                             
-                            if formatted_reasoning:
+                            reasoning_delta = choice.delta.reasoning_content
+                            
+                            # First reasoning chunk - output header once
+                            if not reasoning_content_started:
+                                reasoning_content_started = True
                                 yield PartialResponse(
-                                    text=formatted_reasoning,
+                                    text="Thinking...\n",
                                     raw_response=response,
                                     request_id=response.id,
                                 )
-                        
+                            
+                            # Format reasoning delta with > prefix
+                            formatted_delta = ""
+                            for line in reasoning_delta.split('\n'):
+                                if line.strip():
+                                    formatted_delta += f"> {line}\n"
+                                elif reasoning_delta.endswith('\n'):
+                                    formatted_delta += "\n"
+                            
+                            if formatted_delta:
+                                yield PartialResponse(
+                                    text=formatted_delta,
+                                    raw_response=response,
+                                    request_id=response.id,
+                                )
+                            
+                            continue
 
-
+                        # Transition from reasoning to regular content
+                        if reasoning_content_started and choice.delta.content is not None:
+                            yield PartialResponse(
+                                text="\n",  # Spacing after reasoning
+                                raw_response=response,
+                                request_id=response.id,
+                            )
+                            reasoning_content_started = False
 
                         if choice.delta.content is None:
                             continue

--- a/fireworks_poe_bot/fw_poe_text_bot.py
+++ b/fireworks_poe_bot/fw_poe_text_bot.py
@@ -636,20 +636,23 @@ class FireworksPoeTextBot(PoeBot):
                                 raw_response=response,
                                 request_id=response.id,
                             )
-                            
+
+                            # If this delta only has reasoning content, skip to next delta
+                            if choice.delta.content is None:
+                                continue
+
+                        # Handle regular content
+                        if choice.delta.content is None:
                             continue
 
-                        # Transition from reasoning to regular content
-                        if reasoning_content_started and choice.delta.content is not None:
+                        # Transition from reasoning to regular content (only when we have actual content)
+                        if reasoning_content_started:
                             yield PartialResponse(
-                                text="\n",  # Spacing after reasoning
+                                text="\n\n",  # Double spacing after reasoning
                                 raw_response=response,
                                 request_id=response.id,
                             )
                             reasoning_content_started = False
-
-                        if choice.delta.content is None:
-                            continue
 
                         token_count += 1
                         


### PR DESCRIPTION
# Add reasoning content support for newer thinking models

## Summary
Adds support for displaying reasoning content from GLM and OpenAI GPT OSS models that use the `reasoning_content` field instead of `<think>` tags. Users now see the thinking process for these models in the same format as DeepSeek R1.

## Changes
- Added `show_reasoning_content` config option
- Implemented streaming reasoning content processing  
- Added proper state management for thinking/response transitions
- Maintained backward compatibility with existing `<think>` tag models

## Result
All reasoning models now show thinking in consistent format:

```
Thinking...
> Model's reasoning process appears here
> With proper indentation and formatting

Actual response appears outside the gray thinking box
```


## Testing
✅ Verified with GLM and Open AI GPT OSS models showing reasoning content  
✅ Confirmed DeepSeek R1 models unchanged
✅ Tested streaming and state transitions